### PR TITLE
remove babel-plugin-transform-runtime #6 add keywords for npm-search

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "name": "gatsby-source-graphcms",
   "description": "Gatsby source plugin for building websites using the GraphCMS as a data source.",
   "keywords": [
+    "data",
     "gatsby",
-    "graphcms"
+    "gatsby-plugin",
+    "graphcms",
+    "graphql",
+    "source"
   ],
   "homepage": "https://github.com/GraphCMS/gatsby-source-graphcms",
   "repository": {
@@ -30,7 +34,6 @@
     "babel-cli": "6.26.0",
     "babel-eslint": "8.0.2",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
-    "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.6.1",
     "cross-env": "5.1.1",
     "jest": "21.2.1",
@@ -49,7 +52,10 @@
     "overrides": [
       {
         "files": "src/__tests__/*.js",
-        "globals": ["it", "expect"]
+        "globals": [
+          "it",
+          "expect"
+        ]
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,12 +690,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
closes #6 

removal of `babel-plugin-transform-runtime` still builds on node 4 via Circle on my fork and plugin works in example local test

added keywords to get us ready for upcoming Algolia powered [NPM search](https://github.com/algolia/npm-search)!
critically `gatsby-plugin`
See for example:
https://yarnpkg.com/en/packages?q=gatsby&p=1&keywords%5B0%5D=gatsby-plugin

