### PR TITLE
[Chore] Reduce renovate noise

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,15 @@
     ],
     "assignees": [
       "rdela"
-    ]
+    ],
+    "devDependencies": {
+      "schedule": [
+        "on the first day of the month"
+      ],
+      "automerge": true,
+      "major": {
+        "automerge": false
+      }
+    }
   }
 }


### PR DESCRIPTION
Added a schedule to the renovate PRs for dev dependencies, and enabled automerging for everything but major version changes.

Is the schedule of once a month frequent enough, or should we merge more frequently?