### PR TITLE
Revert "chore(deps): pin docker digests"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "renovate": {
     "extends": [
       "config:base",
-      "default:pinDigestsDisabled"
+      "docker:disable"
     ],
     "labels": [
       "renovate"


### PR DESCRIPTION
Reverts GraphCMS/gatsby-source-graphcms#39 in order to test the fix for `docker:disable`