### PR TITLE
Refactor creation of headers

### DIFF
--- a/src/__tests__/util.test.js
+++ b/src/__tests__/util.test.js
@@ -4,7 +4,8 @@ import {
   surroundWithBraces,
   constructTypeQuery,
   assembleQueries,
-  createNodes
+  createNodes,
+  createdHeaders
 } from '../util';
 
 describe('Util function tests', () => {
@@ -85,6 +86,12 @@ describe('Util function tests', () => {
         createNode.mock.calls[1][0]
       );
       expect(reporter).not.toHaveBeenCalled();
+    });
+
+    it('creates a Headers object', () => {
+      expect(createdHeaders()).toMatchObject({});
+      expect(createdHeaders('foo')).toMatchObject({headers: {Origin: 'foo'}});
+      expect(createdHeaders('foo', 'bar')).toMatchObject({headers: {Origin: 'foo', Authorization: 'Bearer bar'}});
     });
   });
 });

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -7,22 +7,24 @@ import {
   checkForFaultyFields
 } from './faulty-keywords';
 
+const setHeaders = (origin, token) => {
+  let headers = {};
+  if (origin) {
+    headers = Object.assign(headers, {"Origin": origin})
+  }
+  if (token) {
+    headers = Object.assign(headers, {"Authorization": `Bearer ${token}`})
+  }
+  return Object.keys(headers).length === 0 ? {} : { headers };
+};
+
 exports.sourceNodes = async (
   {boundActionCreators, reporter},
   {endpoint, token, query, origin}
 ) => {
   if (query) {
     const {createNode} = boundActionCreators;
-
-    const clientOptions = {
-      headers: {
-        Origin: origin || '',
-        Authorization: token ? `Bearer ${token}` : undefined
-      }
-    };
-
-    const client = new GraphQLClient(endpoint, clientOptions);
-
+    const client = new GraphQLClient(endpoint, setHeaders(origin, token));
     const userQueryResult = await client.request(query);
 
     // Keywords workaround

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,22 +1,11 @@
 import {GraphQLClient} from 'graphql-request';
 import {forEachObjIndexed} from 'ramda';
-import {createNodes} from './util';
+import {createNodes, createdHeaders} from './util';
 import {DEBUG_MODE} from './constants';
 import {
   keywordsError,
   checkForFaultyFields
 } from './faulty-keywords';
-
-const setHeaders = (origin, token) => {
-  let headers = {};
-  if (origin) {
-    headers = Object.assign(headers, {"Origin": origin})
-  }
-  if (token) {
-    headers = Object.assign(headers, {"Authorization": `Bearer ${token}`})
-  }
-  return Object.keys(headers).length === 0 ? {} : { headers };
-};
 
 exports.sourceNodes = async (
   {boundActionCreators, reporter},
@@ -24,7 +13,7 @@ exports.sourceNodes = async (
 ) => {
   if (query) {
     const {createNode} = boundActionCreators;
-    const client = new GraphQLClient(endpoint, setHeaders(origin, token));
+    const client = new GraphQLClient(endpoint, createdHeaders(origin, token));
     const userQueryResult = await client.request(query);
 
     // Keywords workaround

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import {compose, join, pluck, map, path, forEach} from 'ramda';
+import {compose, join, pluck, map, path, forEach, isEmpty, merge} from 'ramda';
 import {singular, plural} from 'pluralize';
 
 import {SOURCE_NAME, DEBUG_MODE} from './constants';
@@ -55,4 +55,16 @@ export const createNodes = (createNode, reporter) => (value, key) => {
 
     createNode(gatsbyNode);
   }, value);
+};
+
+// Construct Headers object for GraphQLClient
+export const createdHeaders = (origin, token) => {
+  let headers = {};
+  if (origin) {
+    headers = merge(headers, {Origin: origin});
+  }
+  if (token) {
+    headers = merge(headers, {Authorization: `Bearer ${token}`});
+  }
+  return isEmpty(headers) ? {} : {headers};
 };


### PR DESCRIPTION
This PR refactors how headers are created.

I found the existing method cause Authorization errors regardless if the dashboard URL was public, or was protected and a token was provided.

```
// This is the response from an 'open' URL

Error: Not Authorised!: {"response":{"errors":[{"message":"Not Authorised!","locations":[{"line":2,"column":11}],"path  ":["pages"]}],"data":null,"status":500},"request":{"query":"{\n          pages {\n            id\n            title\n            }\n        }"}}
```

``` 
// This is the response from a 'protected' URL with a token provided

TypeError: Cannot read property '1' of null 
```

This proposed change only includes headers keys if their values are provided.
