### PR TITLE
feat: Build Gatsby nodes

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-source-graphcms',
+      options: {
+        endpoint:
+          'https://api-eu-central-1.graphcms.com/v2/ck8sn5tnf01gc01z89dbc7s0o/master',
+      },
+    },
+  ],
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "gatsby": "2.23.22",
-    "gatsby-source-graphcms": "*",
+    "gatsby-source-graphcms": "2.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   }

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -17,7 +17,7 @@ const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
     remoteIdFields: ['__typename', 'id'],
     queries: `query LIST_${pluralize(type.name).toUpperCase()} { ${pluralize(
       type.name.toLowerCase()
-    )}(limit: $limit, skip: $skip) }`,
+    )}(first: $limit, skip: $offset) }`,
   }))
 
   const fragments = generateDefaultFragments({ schema, gatsbyNodeTypes })

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -2,6 +2,10 @@ const {
   createDefaultQueryExecutor,
   loadSchema,
   generateDefaultFragments,
+  compileNodeQueries,
+  buildNodeDefinitions,
+  createSchemaCustomization,
+  sourceAllNodes,
 } = require('gatsby-graphql-source-toolkit')
 const pluralize = require('pluralize')
 
@@ -21,8 +25,26 @@ const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
   }))
 
   const fragments = generateDefaultFragments({ schema, gatsbyNodeTypes })
+
+  const documents = compileNodeQueries({
+    schema,
+    gatsbyNodeTypes,
+    customFragments: fragments,
+  })
+
+  return {
+    gatsbyApi,
+    schema,
+    execute,
+    gatsbyTypePrefix: `GraphCMS_`,
+    gatsbyNodeDefs: buildNodeDefinitions({ gatsbyNodeTypes, documents }),
+  }
 }
 
 exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
   const config = await createSourcingConfig(gatsbyApi, pluginOptions)
+
+  await createSchemaCustomization(config)
+
+  await sourceAllNodes(config)
 }

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -1,0 +1,28 @@
+const {
+  createDefaultQueryExecutor,
+  loadSchema,
+  generateDefaultFragments,
+} = require('gatsby-graphql-source-toolkit')
+const pluralize = require('pluralize')
+
+const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
+  const execute = createDefaultQueryExecutor(endpoint)
+  const schema = await loadSchema(execute)
+
+  const nodeInterface = schema.getType('Node')
+  const possibleTypes = schema.getPossibleTypes(nodeInterface)
+
+  const gatsbyNodeTypes = possibleTypes.map((type) => ({
+    remoteTypeName: type,
+    remoteIdFields: ['__typename', 'id'],
+    queries: `query LIST_${pluralize(
+      type
+    ).toUpperCase()} { products(limit: $limit, skip: $skip) }`,
+  }))
+
+  const fragments = generateDefaultFragments({ schema, gatsbyNodeTypes })
+}
+
+exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
+  const config = await createSourcingConfig(gatsbyApi, pluginOptions)
+}

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -13,10 +13,10 @@ const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
   const possibleTypes = schema.getPossibleTypes(nodeInterface)
 
   const gatsbyNodeTypes = possibleTypes.map((type) => ({
-    remoteTypeName: type,
+    remoteTypeName: type.name,
     remoteIdFields: ['__typename', 'id'],
-    queries: `query LIST_${pluralize(type).toUpperCase()} { ${pluralize(
-      type
+    queries: `query LIST_${pluralize(type.name).toUpperCase()} { ${pluralize(
+      type.name.toLowerCase()
     )}(limit: $limit, skip: $skip) }`,
   }))
 

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -15,9 +15,9 @@ const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
   const gatsbyNodeTypes = possibleTypes.map((type) => ({
     remoteTypeName: type,
     remoteIdFields: ['__typename', 'id'],
-    queries: `query LIST_${pluralize(
+    queries: `query LIST_${pluralize(type).toUpperCase()} { ${pluralize(
       type
-    ).toUpperCase()} { products(limit: $limit, skip: $skip) }`,
+    )}(limit: $limit, skip: $skip) }`,
   }))
 
   const fragments = generateDefaultFragments({ schema, gatsbyNodeTypes })

--- a/gatsby-source-graphcms/package.json
+++ b/gatsby-source-graphcms/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gatsby-graphql-source-toolkit": "0.2.0",
+    "gatsby-graphql-source-toolkit": "0.2.2",
     "pluralize": "8.0.0"
   }
 }

--- a/gatsby-source-graphcms/package.json
+++ b/gatsby-source-graphcms/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gatsby-graphql-source-toolkit": "0.2.0"
+    "gatsby-graphql-source-toolkit": "0.2.0",
+    "pluralize": "8.0.0"
   }
 }

--- a/gatsby-source-graphcms/package.json
+++ b/gatsby-source-graphcms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-graphcms",
-  "version": "1.0.0-alpha.3",
+  "version": "2.0.0",
   "description": "Gatsby source plugin for building websites using the GraphCMS as a data source.",
   "main": "index.js",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,10 +4882,10 @@ gatsby-graphiql-explorer@^0.4.10:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
-gatsby-graphql-source-toolkit@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/gatsby-graphql-source-toolkit/-/gatsby-graphql-source-toolkit-0.2.0.tgz#a40c7685d579a862e67c2ed30c42ac4dd0ebd2c2"
-  integrity sha512-9S26sev19KfeoZB/vp7vUamonLz/w9HlEa15Q5+fXsmKtpNREzxJt+qsTvBbkDqTxl+3CCG0bD8sxnj0kbzIng==
+gatsby-graphql-source-toolkit@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/gatsby-graphql-source-toolkit/-/gatsby-graphql-source-toolkit-0.2.2.tgz#07c37eb23c330099c9e9d3d59b3981a999a1ab2f"
+  integrity sha512-gx98EGdzpq3LDd5YNTSdciZDExhOQRLW2kzrc9tLf61N2oV3pnQ1zIrQ5RJHNjKwLUndyfDRmK85bYqYLLcPuA==
   dependencies:
     "@types/node-fetch" "^2.5.7"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,9 +1283,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "14.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.18.tgz#5111b2285659442f9f95697386a2b42b875bd7e9"
-  integrity sha512-0Z3nS5acM0cIV4JPzrj9g/GH0Et5vmADWtip3YOXOp1NpOLU8V3KoZDc8ny9c1pe/YSYYzQkAWob6dyV/EWg4g==
+  version "14.0.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.19.tgz#994d99708822bca643a2364f8aeed04a16e0f5a1"
+  integrity sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag==
 
 "@types/node@^8.5.7":
   version "8.10.61"
@@ -3882,9 +3882,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.488:
-  version "1.3.489"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.489.tgz#6e87ed17744c85629ca6f567e5bc7ebe67652f57"
-  integrity sha512-1FfqjT+IXbs/H9bGJwRIyQQqOXIo7mOVUnv8s7nb2ff01fD0Z8dn1YjKovLDCFe4900Dal2uutR0YzXN5ldqEQ==
+  version "1.3.490"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.490.tgz#12aa776c493e66ba21536512fc317bdda6d04cd4"
+  integrity sha512-jKJF1mKXrQkT0ZiuJ/oV63Q02hAeWz0GGt/z6ryc518uCHtMyS9+wYAysZtBQ8rsjqFPAYXV4TIz5GQ8xyubPA==
 
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.3"
@@ -5015,15 +5015,6 @@ gatsby-recipes@^0.1.50:
     ws "^7.3.0"
     xstate "^4.11.0"
 
-gatsby-source-graphcms@*:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-source-graphcms/-/gatsby-source-graphcms-0.0.1.tgz#129c5e68b18053a4c90e1f7170d39daa96308783"
-  integrity sha1-EpxeaLGAU6TJDh9xcNOdqpYwh4M=
-  dependencies:
-    babel-runtime "^6.26.0"
-    graphql-request "^1.3.4"
-    ramda "^0.25.0"
-
 gatsby-telemetry@^1.3.18:
   version "1.3.18"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.18.tgz#bb1ac30a04c1f2f5daa0b236753abf4c6b2ec4aa"
@@ -5426,7 +5417,7 @@ graphql-playground-middleware-express@^1.7.18:
   dependencies:
     graphql-playground-html "1.6.25"
 
-graphql-request@^1.3.4, graphql-request@^1.5.0:
+graphql-request@^1.5.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
   integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
@@ -8882,11 +8873,6 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
-
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5015,6 +5015,15 @@ gatsby-recipes@^0.1.50:
     ws "^7.3.0"
     xstate "^4.11.0"
 
+gatsby-source-graphcms@*:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-source-graphcms/-/gatsby-source-graphcms-0.0.1.tgz#129c5e68b18053a4c90e1f7170d39daa96308783"
+  integrity sha1-EpxeaLGAU6TJDh9xcNOdqpYwh4M=
+  dependencies:
+    babel-runtime "^6.26.0"
+    graphql-request "^1.3.4"
+    ramda "^0.25.0"
+
 gatsby-telemetry@^1.3.18:
   version "1.3.18"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.18.tgz#bb1ac30a04c1f2f5daa0b236753abf4c6b2ec4aa"
@@ -5417,7 +5426,7 @@ graphql-playground-middleware-express@^1.7.18:
   dependencies:
     graphql-playground-html "1.6.25"
 
-graphql-request@^1.5.0:
+graphql-request@^1.3.4, graphql-request@^1.5.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
   integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
@@ -8282,6 +8291,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pluralize@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pnp-webpack-plugin@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
@@ -8868,6 +8882,11 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Use `gatsby-graphql-source-toolkit` to build Gatsby nodes for types from a remote GraphCMS project schema.