### PR TITLE
feat: Build files nodes for GraphCMS image assets

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       resolve: 'gatsby-source-graphcms',
       options: {
+        downloadLocalImages: true,
         endpoint:
           'https://api-eu-central-1.graphcms.com/v2/ck8sn5tnf01gc01z89dbc7s0o/master',
       },

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -67,7 +67,7 @@ exports.onCreateNode = async (
       getCache,
     })
 
-    if (fileNode) node.file = fileNode.id
+    if (fileNode) node.localFile = fileNode.id
   }
 }
 
@@ -78,7 +78,7 @@ exports.createSchemaCustomization = (
   if (downloadLocalImages)
     createTypes(`
     type GraphCMS_Asset {
-      file: File @link
+      localFile: File @link
     }
   `)
 }

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -50,13 +50,15 @@ exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
   await sourceAllNodes(config)
 }
 
-exports.onCreateNode = async ({
-  node,
-  actions: { createNode },
-  createNodeId,
-  getCache,
-}) => {
-  if (node.remoteTypeName === 'Asset' && node.mimeType.includes('image/')) {
+exports.onCreateNode = async (
+  { node, actions: { createNode }, createNodeId, getCache },
+  { downloadLocalImages = false }
+) => {
+  if (
+    downloadLocalImages &&
+    node.remoteTypeName === 'Asset' &&
+    node.mimeType.includes('image/')
+  ) {
     const fileNode = await createRemoteFileNode({
       url: node.url,
       parentNodeId: node.id,
@@ -69,8 +71,12 @@ exports.onCreateNode = async ({
   }
 }
 
-exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
-  createTypes(`
+exports.createSchemaCustomization = (
+  { actions: { createTypes } },
+  { downloadLocalImages = false }
+) => {
+  if (downloadLocalImages)
+    createTypes(`
     type GraphCMS_Asset {
       file: File @link
     }

--- a/gatsby-source-graphcms/package.json
+++ b/gatsby-source-graphcms/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "gatsby-graphql-source-toolkit": "0.2.2",
+    "gatsby-source-filesystem": "2.3.18",
     "pluralize": "8.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4604,6 +4604,11 @@ file-loader@^1.1.11:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
 
+file-type@^12.4.2:
+  version "12.4.2"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-12.4.2.tgz#a344ea5664a1d01447ee7fb1b635f72feb6169d9"
+  integrity sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -5013,6 +5018,27 @@ gatsby-recipes@^0.1.50:
     unist-util-visit "^2.0.2"
     urql "^1.9.8"
     ws "^7.3.0"
+    xstate "^4.11.0"
+
+gatsby-source-filesystem@2.3.18:
+  version "2.3.18"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.3.18.tgz#b86d914d3c94b2e5e48bdcb2ce04b1ec12272181"
+  integrity sha512-HcPhm8yIYrpSVCVOiCzE8dGOKfv78Dvw8p86COE/EbvqRyXQ7x2N+v5dZSluSejtoXck0vISa2kJCGPTGzcsbw==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    better-queue "^3.8.10"
+    bluebird "^3.7.2"
+    chokidar "3.4.0"
+    file-type "^12.4.2"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.3.11"
+    got "^9.6.0"
+    md5-file "^3.2.3"
+    mime "^2.4.6"
+    pretty-bytes "^5.3.0"
+    progress "^2.0.3"
+    read-chunk "^3.2.0"
+    valid-url "^1.0.9"
     xstate "^4.11.0"
 
 gatsby-telemetry@^1.3.18:
@@ -7972,7 +7998,7 @@ p-try@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
-p-try@^2.0.0:
+p-try@^2.0.0, p-try@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
@@ -8677,6 +8703,11 @@ prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
+pretty-bytes@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
+  integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
+
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -9025,6 +9056,14 @@ react@16.13.1, react@^16.8.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+read-chunk@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-3.2.0.tgz#2984afe78ca9bfbbdb74b19387bf9e86289c16ca"
+  integrity sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==
+  dependencies:
+    pify "^4.0.1"
+    with-open-file "^0.1.6"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -11062,6 +11101,11 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -11333,6 +11377,15 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+with-open-file@^0.1.6:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/with-open-file/-/with-open-file-0.1.7.tgz#e2de8d974e8a8ae6e58886be4fe8e7465b58a729"
+  integrity sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==
+  dependencies:
+    p-finally "^1.0.0"
+    p-try "^2.1.0"
+    pify "^4.0.1"
 
 wonka@^4.0.14:
   version "4.0.14"


### PR DESCRIPTION
Uses `createRemoteFileNode` to build local file nodes for GraphCMS images.

Can be used with `gatsby-image` etc.

This features is opt in, must be enabled in `gatsby-config.js`:

```js
{
  resolve: 'gatsby-source-graphcms',
  options: {
    downloadLocalImages: true
  }
}
```