### PR TITLE
fix: Use correct root query fields

### DIFF
--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -10,7 +10,6 @@ const {
 } = require('gatsby-graphql-source-toolkit')
 const { createRemoteFileNode } = require('gatsby-source-filesystem')
 const fetch = require('node-fetch')
-const pluralize = require('pluralize')
 
 exports.onPreBootstrap = ({ reporter }, pluginOptions) => {
   if (!pluginOptions || !pluginOptions.endpoint)
@@ -33,18 +32,30 @@ const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
   const schema = await loadSchema(execute)
 
   const nodeInterface = schema.getType('Node')
+  const query = schema.getType('Query')
+  const queryFields = query.getFields()
   const possibleTypes = schema.getPossibleTypes(nodeInterface)
+
+  const singularRootFieldName = (type) =>
+    Object.keys(queryFields).find(
+      (fieldName) => queryFields[fieldName].type === type
+    )
+
+  const pluralRootFieldName = (type) =>
+    Object.keys(queryFields).find(
+      (fieldName) => String(queryFields[fieldName].type) === `[${type.name}!]!`
+    )
 
   const gatsbyNodeTypes = possibleTypes.map((type) => ({
     remoteTypeName: type.name,
     remoteIdFields: ['__typename', 'id'],
     queries: `
-      query LIST_${pluralize(type.name).toUpperCase()} { ${pluralize(
-      type.name.toLowerCase()
+      query LIST_${pluralRootFieldName(type)} { ${pluralRootFieldName(
+      type
     )}(first: $limit, skip: $offset) }
-      query NODE_${type.name.toUpperCase()}($where: ${
+      query NODE_${singularRootFieldName(type)}($where: ${
       type.name
-    }WhereUniqueInput!) { ${type.name.toLowerCase()}(where: $where) }`,
+    }WhereUniqueInput!) { ${singularRootFieldName(type)}(where: $where) }`,
     nodeQueryVariables: ({ id }) => ({ where: { id } }),
   }))
 

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -53,9 +53,9 @@ const createSourcingConfig = async (gatsbyApi, { endpoint, token }) => {
       query LIST_${pluralRootFieldName(type)} { ${pluralRootFieldName(
       type
     )}(first: $limit, skip: $offset) }
-      query NODE_${singularRootFieldName(type)}($where: ${
-      type.name
-    }WhereUniqueInput!) { ${singularRootFieldName(type)}(where: $where) }`,
+      query NODE_${singularRootFieldName(type)} { ${singularRootFieldName(
+      type
+    )}(where: $where) }`,
     nodeQueryVariables: ({ id }) => ({ where: { id } }),
   }))
 

--- a/gatsby-source-graphcms/package.json
+++ b/gatsby-source-graphcms/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "gatsby-graphql-source-toolkit": "0.2.2",
     "gatsby-source-filesystem": "2.3.18",
-    "node-fetch": "2.6.0",
-    "pluralize": "8.0.0"
+    "node-fetch": "2.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9888,11 +9888,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pluralize@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
-
 pngjs@^3.0.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"


### PR DESCRIPTION
When writing the GraphCMS queries to source data for nodes, use the root query fields from the GraphQL schema.

Previously these were compiled using the schema `type` names. However query fields can be specified by GraphCMS users during model creation so they may differ entirely from the model name/type.