### PR TITLE
fix: Decode markdown field returned from GraphCMS

### DIFF
--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -10,6 +10,7 @@ const {
   sourceNodeChanges,
 } = require('gatsby-graphql-source-toolkit')
 const { createRemoteFileNode } = require('gatsby-source-filesystem')
+const he = require('he')
 const fetch = require('node-fetch')
 
 exports.onPreBootstrap = ({ reporter }, pluginOptions) => {
@@ -149,16 +150,18 @@ exports.onCreateNode = async (
 
     if (fields.length) {
       fields.forEach((field) => {
+        const decodedMarkdown = he.decode(field.markdown)
+
         const markdownNode = {
           id: `MarkdownNode:${createNodeId(node.id)}`,
           parent: node.id,
           internal: {
             type: `GraphCMS_MarkdownNode`,
             mediaType: 'text/markdown',
-            content: field.markdown,
+            content: decodedMarkdown,
             contentDigest: crypto
               .createHash(`md5`)
-              .update(field.markdown)
+              .update(decodedMarkdown)
               .digest(`hex`),
           },
         }

--- a/gatsby-source-graphcms/package.json
+++ b/gatsby-source-graphcms/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "gatsby-graphql-source-toolkit": "0.2.2",
     "gatsby-source-filesystem": "2.3.18",
+    "he": "1.2.0",
     "node-fetch": "2.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7179,6 +7179,11 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 header-case@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/header-case/-/header-case-1.0.1.tgz#9535973197c144b09613cd65d317ef19963bd02d"


### PR DESCRIPTION
HTML characters are escaped in JSON response for markdown fields, which prevents using components directly in CMS entries.