### PR TITLE
fix: Check if type has locale field

### DIFF
--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -63,11 +63,7 @@ const createSourcingConfig = async (
       (fieldName) => String(queryFields[fieldName].type) === `[${type.name}!]!`
     )
 
-  const hasLocaleField = (type) => {
-    const fieldName = pluralRootFieldName(type)
-
-    return queryFields[fieldName].args.some((arg) => arg.name === `locales`)
-  }
+  const hasLocaleField = (type) => type.getFields().locale
 
   const gatsbyNodeTypes = possibleTypes.map((type) => ({
     remoteTypeName: type.name,


### PR DESCRIPTION
Check if type has `locale` field as opposed to  checking for `locales` argument, which is now available on all types regardless of if localisation is present.

Fixes #123.