### PR TITLE
feat: All configuration for multiple instances

### DIFF
--- a/gatsby-source-graphcms/README.md
+++ b/gatsby-source-graphcms/README.md
@@ -77,7 +77,7 @@ module.exports = {
 
 - `fragmentsPath` _String_ (default value: `graphcms-fragments`)
 
-  > If using multiple instances of the source plugin, you **must** provide a value here to prevent type conflicts.
+  > If using multiple instances of the source plugin, you **must** provide a value here to prevent type and/or fragment conflicts.
 
   - The local project path where generated query fragments are saved. This is relative to your current working directory.
 

--- a/gatsby-source-graphcms/README.md
+++ b/gatsby-source-graphcms/README.md
@@ -63,7 +63,9 @@ module.exports = {
 
 - `typePrefix` _String_ (default value: `GraphCMS_`)
 
-  - The string by which every generated type name is prefixed with. For example, a type of `Post` in GraphCMS would become `GraphCMS_Post` by default. If using multiple instances of the source plugin, you **must** provide a value here to prevent type conflicts.
+  > If using multiple instances of the source plugin, you **must** provide a value here to prevent type conflicts.
+
+  - The string by which every generated type name is prefixed with. For example, a type of `Post` in GraphCMS would become `GraphCMS_Post` by default.
 
 - `downloadLocalImages` _Boolean_ (default value: `false`)
 
@@ -74,6 +76,8 @@ module.exports = {
   - Build markdown nodes for all [`RichText`](https://graphcms.com/docs/reference/fields/rich-text) fields in your GraphCMS schema. [Learn more](#using-markdown-nodes).
 
 - `fragmentsPath` _String_ (default value: `graphcms-fragments`)
+
+  > If using multiple instances of the source plugin, you **must** provide a value here to prevent type conflicts.
 
   - The local project path where generated query fragments are saved. This is relative to your current working directory.
 

--- a/gatsby-source-graphcms/README.md
+++ b/gatsby-source-graphcms/README.md
@@ -61,6 +61,10 @@ module.exports = {
 
   - If your GraphCMS project is **not** publicly accessible, you will need to provide a [Permanent Auth Token](https://graphcms.com/docs/reference/authorization) to correctly authorize with the API. You can learn more about creating and managing API tokens [here](https://graphcms.com/docs/guides/concepts/apis#working-with-apis).
 
+- `typePrefix` _String_ (default value: `GraphCMS_`)
+
+  - The string by which every generated type name is prefixed with. For example, a type of `Post` in GraphCMS would become `GraphCMS_Post` by default. If using multiple instances of the source plugin, you **must** provide a value here to prevent type conflicts.
+
 - `downloadLocalImages` _Boolean_ (default value: `false`)
 
   - Download and cache GraphCMS image assets in your Gatsby project. [Learn more](#downloading-local-image-assets).

--- a/gatsby-source-graphcms/gatsby-node.js
+++ b/gatsby-source-graphcms/gatsby-node.js
@@ -34,7 +34,13 @@ exports.onPreBootstrap = ({ reporter }, pluginOptions) => {
 
 const createSourcingConfig = async (
   gatsbyApi,
-  { endpoint, fragmentsPath = 'graphcms-fragments', locales = ['en'], token }
+  {
+    endpoint,
+    fragmentsPath = 'graphcms-fragments',
+    locales = ['en'],
+    token,
+    typePrefix = 'GraphCMS_',
+  }
 ) => {
   const execute = async ({ operationName, query, variables = {} }) => {
     return await fetch(endpoint, {
@@ -122,7 +128,7 @@ const createSourcingConfig = async (
     gatsbyApi,
     schema,
     execute: wrapQueryExecutorWithQueue(execute, { concurrency: 10 }),
-    gatsbyTypePrefix: `GraphCMS_`,
+    gatsbyTypePrefix: typePrefix,
     gatsbyNodeDefs: buildNodeDefinitions({ gatsbyNodeTypes, documents }),
   }
 }


### PR DESCRIPTION
* Adds `typePrefix` configuration value to be used during Gatsby node building to prevent any type conflicts. Defaults to `GraphCMS_`
* Add note to `README` to recommend using `fragmentsPath` when using multiple source plugin instances.

Using these 2 configuration values is **strongly** recommended if using multiple instances of the source plugin in a single Gatsby project.