### PR TITLE
feat: Use fileName field from Asset type when generating local file

### DIFF
--- a/demo/graphcms-fragments/Category.graphql
+++ b/demo/graphcms-fragments/Category.graphql
@@ -1,0 +1,16 @@
+fragment Category on Category {
+  stage
+  locale
+  remoteId: id
+  createdAt(variation: COMBINED)
+  updatedAt(variation: COMBINED)
+  publishedAt(variation: COMBINED)
+  name
+  products {
+    ... on Product {
+      remoteTypeName: __typename
+      remoteId: id
+      locale
+    }
+  }
+}

--- a/demo/graphcms-fragments/Product.graphql
+++ b/demo/graphcms-fragments/Product.graphql
@@ -23,4 +23,11 @@ fragment Product on Product {
       locale
     }
   }
+  categories {
+    ... on Category {
+      remoteTypeName: __typename
+      remoteId: id
+      locale
+    }
+  }
 }

--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -244,6 +244,7 @@ exports.onCreateNode = async (
         createNode,
         createNodeId,
         getCache,
+        ...(node.fileName && { name: node.fileName }),
       })
 
       if (fileNode) node.localFile = fileNode.id


### PR DESCRIPTION
Use `fileName` field on Asset type (if queried) to build local asset node.

The file name can't be determined from the CDN URL so this is required for more SEO compliant images. 