### PR TITLE
fix: Ensure `locale` option has items

### DIFF
--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -41,7 +41,7 @@ exports.pluginOptionsSchema = ({ Joi }) => {
         `An array of locale key strings from your GraphCMS project. You can read more about working with localisation in GraphCMS [here](https://graphcms.com/docs/guides/concepts/i18n).`
       )
       .items(Joi.string())
-      .length(1)
+      .min(1)
       .default(['en']),
     token: Joi.string().description(
       `If your GraphCMS project is **not** publicly accessible, you will need to provide a [Permanent Auth Token](https://graphcms.com/docs/reference/authorization) to correctly authorize with the API. You can learn more about creating and managing API tokens [here](https://graphcms.com/docs/guides/concepts/apis#working-with-apis)`

--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -55,13 +55,7 @@ exports.pluginOptionsSchema = ({ Joi }) => {
 
 const createSourcingConfig = async (
   gatsbyApi,
-  {
-    endpoint,
-    fragmentsPath = 'graphcms-fragments',
-    locales = ['en'],
-    token,
-    typePrefix = 'GraphCMS_',
-  }
+  { endpoint, fragmentsPath, locales, token, typePrefix }
 ) => {
   const execute = async ({ operationName, query, variables = {} }) => {
     const { reporter } = gatsbyApi

--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -41,6 +41,7 @@ exports.pluginOptionsSchema = ({ Joi }) => {
         `An array of locale key strings from your GraphCMS project. You can read more about working with localisation in GraphCMS [here](https://graphcms.com/docs/guides/concepts/i18n).`
       )
       .items(Joi.string())
+      .length(1)
       .default(['en']),
     token: Joi.string().description(
       `If your GraphCMS project is **not** publicly accessible, you will need to provide a [Permanent Auth Token](https://graphcms.com/docs/reference/authorization) to correctly authorize with the API. You can learn more about creating and managing API tokens [here](https://graphcms.com/docs/guides/concepts/apis#working-with-apis)`

--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -53,24 +53,6 @@ exports.pluginOptionsSchema = ({ Joi }) => {
   })
 }
 
-exports.onPreBootstrap = ({ reporter }, pluginOptions) => {
-  if (!pluginOptions || !pluginOptions.endpoint)
-    return reporter.panic(
-      'gatsby-source-graphcms: You must provide your GraphCMS endpoint URL'
-    )
-
-  if (
-    pluginOptions.locales &&
-    (!Array.isArray(pluginOptions.locales) ||
-      pluginOptions.locales.length === 0)
-  )
-    return reporter.panic(
-      `gatsby-source-graphcms: Please provide a valid array of locale key strings (i.e. [
-        ('en', 'de')
-      ]`
-    )
-}
-
 const createSourcingConfig = async (
   gatsbyApi,
   {


### PR DESCRIPTION
Update `pluginOptionsSchema` to ensure `locales` property has at least 1 item.

Also, removed some redundant configuration checking now we're using `pluginOptionsSchema`. 