### PR TITLE
fix(gatsby-source-graphcms): Make `gatsbyImageData` nullable

### DIFF
--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -358,13 +358,16 @@ export function createResolvers(
 
   createResolvers({
     [typeName]: {
-      gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData, {
-        quality: {
-          type: 'Int',
-          description:
-            'The default image quality generated. This is overridden by any format-specific options.',
-        },
-      }),
+      gatsbyImageData: {
+        ...getGatsbyImageResolver(resolveGatsbyImageData, {
+          quality: {
+            type: 'Int',
+            description:
+              'The default image quality generated. This is overridden by any format-specific options.',
+          },
+        }),
+        type: 'JSON',
+      },
     },
   })
 }


### PR DESCRIPTION
Allow a null return value from the `gatsbyImageData` resolver, to support non-image asset nodes.