### PR TITLE
fix: return null for non images

### DIFF
--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -348,9 +348,9 @@ function makeResolveGatsbyImageData(cache) {
     { handle: filename, height, mimeType, width, url, internal },
     options
   ) {
-    if (!mimeType.includes('image/')) {
-      return null
-    }
+    // if (!mimeType.includes('image/')) {
+    //  return null
+    // }
 
     const imageDataArgs = {
       ...options,

--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -348,9 +348,11 @@ function makeResolveGatsbyImageData(cache) {
     { handle: filename, height, mimeType, width, url, internal },
     options
   ) {
-    // if (!mimeType.includes('image/')) {
-    //  return null
-    // }
+    if (
+      !['image/png', 'image/jpg', 'image/jpeg', 'image/tiff'].includes(mimeType)
+    ) {
+      return null
+    }
 
     const imageDataArgs = {
       ...options,


### PR DESCRIPTION
Revert a temp change to returning null until we have an improved gatsby image resolver.