### PR TITLE
fix: error message not properly formatted

### DIFF
--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -23,6 +23,7 @@ import { PLUGIN_NAME } from './util/constants'
 import { getImageBase64, getBase64DataURI } from './util/getImageBase64'
 import { getImageDominantColor } from './util/getDominantColor'
 import { getTracedSVG } from './util/getTracedSVG'
+import { reportPanic } from './util/reportPanic'
 
 export function pluginOptionsSchema({ Joi }) {
   return Joi.object({
@@ -88,9 +89,11 @@ const createSourcingConfig = async (
     })
       .then((response) => {
         if (!response.ok) {
-          return reporter.panic(
-            `[${PLUGIN_NAME}]: Problem building GraphCMS nodes`,
-            new Error(response.statusText)
+          return reportPanic(
+            1,
+            'Problem building GraphCMS nodes',
+            response.statusText,
+            reporter
           )
         }
 
@@ -98,18 +101,22 @@ const createSourcingConfig = async (
       })
       .then((response) => {
         if (response.errors) {
-          return reporter.panic(
-            `[${PLUGIN_NAME}]: Problem building GraphCMS nodes`,
-            new Error(response.errors)
+          return reportPanic(
+            2,
+            'Problem building GraphCMS nodes',
+            JSON.stringify(response.errors, null, 2),
+            reporter
           )
         }
 
         return response
       })
       .catch((error) => {
-        return reporter.panic(
-          `[${PLUGIN_NAME}]: Problem building GraphCMS nodes`,
-          new Error(error)
+        return reportPanic(
+          3,
+          'Problem building GraphCMS nodes',
+          JSON.stringify(error, null, 2),
+          reporter
         )
       })
   }

--- a/gatsby-source-graphcms/src/util/reportPanic.js
+++ b/gatsby-source-graphcms/src/util/reportPanic.js
@@ -1,0 +1,10 @@
+import { PLUGIN_NAME } from './constants'
+
+export function reportPanic(id, message, error, reporter) {
+  return reporter.panic({
+    context: {
+      id,
+      sourceMessage: `[${PLUGIN_NAME}]: ${message} \n\n ${new Error(error)}`,
+    },
+  })
+}


### PR DESCRIPTION
**Changes proposed:**

After upgrading to Gatsby v3, the `reporter.panic` and `reporter.error` stopped working on the old-school way (passing the message and error as arguments to the function, as we've been doing). That's why it always displays a `[object Object] [object Object]` error message. After diving into this, I've found another way to use the reporter. 

In the screenshot below, there's the new error message (it can change depending on the problem):

<img width="893" alt="Screen Shot 2021-04-20 at 20 52 21" src="https://user-images.githubusercontent.com/26466516/115477489-63ac0780-a21a-11eb-80ce-7ddcb0aa9400.png">

**Additional context:**

Related to #187 

Ps: I'm also going to open an issue on the Gatsby repo to report this bug.

