### PR TITLE
Update baseURI to 'https://media.graphassets.com'

### DIFF
--- a/gatsby-source-graphcms/src/gatsby-node.js
+++ b/gatsby-source-graphcms/src/gatsby-node.js
@@ -387,7 +387,7 @@ const generateImageSource = (
   fit = 'clip',
   { quality = 100 }
 ) => {
-  const src = `https://media.graphcms.com/resize=width:${width},height:${height},fit:${fit}/output=quality:${quality}/${baseURL}`
+  const src = `https://media.graphassets.com/resize=width:${width},height:${height},fit:${fit}/output=quality:${quality}/${baseURL}`
 
   return { src, width, height, format }
 }


### PR DESCRIPTION
GraphCMS will soon [update the asset domain](https://graphcms.notion.site/Our-Asset-Domain-Will-Change-Soon-9c48046b53cf4d1e9be81135d235ab5f) from `media.graphcms.com` to `media.graphassets.com`.